### PR TITLE
Display reach per player count, refactor FactionsList, and create Factions parent component

### DIFF
--- a/src/app/components/factionList/FactionList.jsx
+++ b/src/app/components/factionList/FactionList.jsx
@@ -1,16 +1,12 @@
 'use client';
 
-import { useState } from 'react';
 import factions from '../../../data/factions';
 import Faction from '../faction/Faction';
 import styles from './FactionList.module.css';
 
-export default function FactionList() {
-  const [selectedFactions, setSelectedFactions] = useState([]);
-
+export default function FactionList({ setSelectedFactions }) {
   return (
     <ul className={styles.FactionList}>
-      <h3>Faction - Reach</h3>
       {factions.map(({ title, reach }) => (
         <Faction
           key={title}
@@ -19,9 +15,6 @@ export default function FactionList() {
           setSelectedFactions={setSelectedFactions}
         />
       ))}
-      <li>
-        Total Reach: {selectedFactions.reduce((acc, cur) => acc + cur.reach, 0)}
-      </li>
     </ul>
   );
 }

--- a/src/app/components/factionList/FactionList.jsx
+++ b/src/app/components/factionList/FactionList.jsx
@@ -1,15 +1,16 @@
 'use client';
 
+import { useState } from 'react';
 import factions from '../../../data/factions';
-import { useEffect, useState } from 'react';
 import Faction from '../faction/Faction';
+import styles from './FactionList.module.css';
 
 export default function FactionList() {
   const [selectedFactions, setSelectedFactions] = useState([]);
 
   return (
-    <ul>
-      <li>Faction - Reach</li>
+    <ul className={styles.FactionList}>
+      <h3>Faction - Reach</h3>
       {factions.map(({ title, reach }) => (
         <Faction
           key={title}
@@ -18,9 +19,9 @@ export default function FactionList() {
           setSelectedFactions={setSelectedFactions}
         />
       ))}
-      <div>
+      <li>
         Total Reach: {selectedFactions.reduce((acc, cur) => acc + cur.reach, 0)}
-      </div>
+      </li>
     </ul>
   );
 }

--- a/src/app/components/factionList/FactionList.jsx
+++ b/src/app/components/factionList/FactionList.jsx
@@ -2,12 +2,10 @@
 
 import factions from '../../../data/factions';
 import { useEffect, useState } from 'react';
-import Faction from '../Faction/Faction';
+import Faction from '../faction/Faction';
 
 export default function FactionList() {
   const [selectedFactions, setSelectedFactions] = useState([]);
-
-  console.log('SELECTED FACTIONS:', selectedFactions);
 
   return (
     <ul>

--- a/src/app/components/factionList/FactionList.module.css
+++ b/src/app/components/factionList/FactionList.module.css
@@ -1,14 +1,3 @@
-.FactionList {
-  margin-block: 1rem;
-}
-
-.FactionList h3 {
-  text-decoration: underline;
-  font-size: 1.2rem;
-  font-weight: 500;
-  margin-bottom: 0.25rem;
-}
-
 .FactionList li {
   margin-bottom: 0.25rem;
 }

--- a/src/app/components/factionList/FactionList.module.css
+++ b/src/app/components/factionList/FactionList.module.css
@@ -1,0 +1,14 @@
+.FactionList {
+  margin-block: 1rem;
+}
+
+.FactionList h3 {
+  text-decoration: underline;
+  font-size: 1.2rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}
+
+.FactionList li {
+  margin-bottom: 0.25rem;
+}

--- a/src/app/components/factions/Factions.jsx
+++ b/src/app/components/factions/Factions.jsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { useState } from 'react';
+import FactionList from '../factionList/FactionList';
+import styles from './Factions.module.css';
+
+export default function Factions() {
+  const [selectedFactions, setSelectedFactions] = useState([]);
+
+  return (
+    <div className={styles.Factions}>
+      <h3>Faction - Reach</h3>
+      <FactionList setSelectedFactions={setSelectedFactions} />
+      Total Reach: {selectedFactions.reduce((acc, cur) => acc + cur.reach, 0)}
+    </div>
+  );
+}

--- a/src/app/components/factions/Factions.module.css
+++ b/src/app/components/factions/Factions.module.css
@@ -1,0 +1,10 @@
+.Factions {
+  margin-block: 1rem;
+}
+
+.Factions h3 {
+  text-decoration: underline;
+  font-size: 1.2rem;
+  font-weight: 500;
+  margin-bottom: 0.25rem;
+}

--- a/src/app/components/reachByPlayerCount/ReachByPlayerCount.jsx
+++ b/src/app/components/reachByPlayerCount/ReachByPlayerCount.jsx
@@ -1,0 +1,20 @@
+import reach from '../../../data/reach';
+
+export default function ReachByPlayerCount() {
+  console.log(reach);
+  const data = Object.entries(reach);
+  console.log(data);
+  return (
+    <div>
+      <h2>Reach per Player Count</h2>
+      <ul>
+        {data.map((playerCount) => (
+          <li key={playerCount[0]}>
+            <span>{playerCount[0]} Players</span> -{' '}
+            <span>Reach - {playerCount[1]}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/app/components/reachPerPlayerCount/ReachPerPlayerCount.jsx
+++ b/src/app/components/reachPerPlayerCount/ReachPerPlayerCount.jsx
@@ -1,17 +1,18 @@
 import reach from '../../../data/reach';
+import styles from './ReachPerPlayerCount.module.css';
 
-export default function ReachByPlayerCount() {
+export default function ReachPerPlayerCount() {
   console.log(reach);
   const data = Object.entries(reach);
   console.log(data);
   return (
-    <div>
+    <div className={styles.ReachPerPlayerCount}>
       <h2>Reach per Player Count</h2>
       <ul>
         {data.map((playerCount) => (
           <li key={playerCount[0]}>
             <span>{playerCount[0]} Players</span> -{' '}
-            <span>Reach - {playerCount[1]}</span>
+            <span>Reach: {playerCount[1]}</span>
           </li>
         ))}
       </ul>

--- a/src/app/components/reachPerPlayerCount/ReachPerPlayerCount.module.css
+++ b/src/app/components/reachPerPlayerCount/ReachPerPlayerCount.module.css
@@ -1,0 +1,9 @@
+.ReachPerPlayerCount {
+  border: black solid 0.15rem;
+  border-radius: 0.3rem;
+  padding: 0.5rem;
+}
+
+.ReachPerPlayerCount h2 {
+  font-weight: 500;
+}

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,12 +1,12 @@
 import FactionList from './components/factionList/FactionList';
-import ReachByPlayerCount from './components/reachByPlayerCount/ReachByPlayerCount';
+import ReachPerPlayerCount from './components/reachPerPlayerCount/ReachPerPlayerCount';
 import styles from './page.module.css';
 
 export default function Home() {
   return (
     <main className={styles.main}>
       <h1>Root Reach Calculator</h1>
-      <ReachByPlayerCount />
+      <ReachPerPlayerCount />
       <FactionList />
     </main>
   );

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,10 +1,12 @@
 import FactionList from './components/factionList/FactionList';
+import ReachByPlayerCount from './components/reachByPlayerCount/ReachByPlayerCount';
 import styles from './page.module.css';
 
 export default function Home() {
   return (
     <main className={styles.main}>
       <h1>Root Reach Calculator</h1>
+      <ReachByPlayerCount />
       <FactionList />
     </main>
   );

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,4 +1,3 @@
-import FactionList from './components/factionList/FactionList';
 import Factions from './components/factions/Factions';
 import ReachPerPlayerCount from './components/reachPerPlayerCount/ReachPerPlayerCount';
 import styles from './page.module.css';
@@ -8,7 +7,6 @@ export default function Home() {
     <main className={styles.main}>
       <h1>Root Reach Calculator</h1>
       <ReachPerPlayerCount />
-      {/* <FactionList /> */}
       <Factions />
     </main>
   );

--- a/src/app/page.js
+++ b/src/app/page.js
@@ -1,4 +1,5 @@
 import FactionList from './components/factionList/FactionList';
+import Factions from './components/factions/Factions';
 import ReachPerPlayerCount from './components/reachPerPlayerCount/ReachPerPlayerCount';
 import styles from './page.module.css';
 
@@ -7,7 +8,8 @@ export default function Home() {
     <main className={styles.main}>
       <h1>Root Reach Calculator</h1>
       <ReachPerPlayerCount />
-      <FactionList />
+      {/* <FactionList /> */}
+      <Factions />
     </main>
   );
 }

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -3,8 +3,14 @@
   flex-direction: column;
   /* justify-content: space-between; */
   align-items: center;
-  /* padding: 6rem; */
+  padding: 1rem;
   min-height: 100vh;
+}
+
+.main h1 {
+  margin-bottom: 1rem;
+  font-weight: 600;
+  text-decoration: underline;
 }
 
 /* Enable hover only on non-touch devices */

--- a/src/app/page.module.css
+++ b/src/app/page.module.css
@@ -3,7 +3,7 @@
   flex-direction: column;
   /* justify-content: space-between; */
   align-items: center;
-  padding: 6rem;
+  /* padding: 6rem; */
   min-height: 100vh;
 }
 


### PR DESCRIPTION
The FactionsList has been refactored to only display the list of available/selected factions. It had also been displaying a title and the total reach selected by the user.

Now the Factions parent component will house the title, FactionsList, and total reach as separate elements.